### PR TITLE
Replace PhantomJS (deprecated) with headless Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ ZippyShare downloader written in Python3 using PhantomJS + selenium (Works on Wi
 **NOTE:** Zippyshare is changing the download algorithm regularly, and because of this, i'm using PhantomJS + selenium.  
   
 ## Installing:  
-You need to download PhantomJS and put in the PATH environment:  
-[Windows](https://www.joecolantonio.com/2014/10/14/how-to-install-phantomjs/)  
-[Linux](https://gist.github.com/julionc/7476620)  
-[MAC](http://macappstore.org/phantomjs/)  
+You need to download Chromedriver and put in the PATH environment:  
+http://chromedriver.chromium.org/
   
 And you need selenium module for Python 3:  
 [Selenium](https://pypi.org/project/selenium/)  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ZippyShare downloader written in Python3 using PhantomJS + selenium (Works on Wi
 
 **ZippyDown** is a Python3 script to download files from website: **"http://zippyshare.com"** directly from your terminal, without the need for web browsers.
 
-**NOTE:** Zippyshare is changing the download algorithm regularly, and because of this, i'm using PhantomJS + selenium.  
+**NOTE:** Zippyshare is changing the download algorithm regularly, and because of this, we're using headless Chrome + selenium.  
   
 ## Installing:  
 You need to download Chromedriver and put in the PATH environment:  

--- a/ZippyDown.py
+++ b/ZippyDown.py
@@ -9,9 +9,13 @@ from urllib import parse
 import argparse
 
 from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+options = Options()
+options.headless = True
+driver = webdriver.Chrome(options=options)
 
 BUFFER = 1024 * 8
-driver = webdriver.PhantomJS()
 
 def Download(url, show_only=False, check=False):
     #Get the download URL using PhantomJS


### PR DESCRIPTION
PhantomJS is now deprecated and so, as advised by the error message that is currently produced when running code, changed the driver so that it works with headless Chrome instead now.
Note: will require the chrome driver to be present in PATH. Added this information to README.md as well